### PR TITLE
PHP 8.4 and 8.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cast `DOMDocument::saveHTML()` results to string before passing to `html_entity_decode()` (PHP 8.5 stricter scalar type enforcement)
 - Cast retranslation period to int before building `DateTime::modify()` string to avoid `DateMalformedStringException` in PHP 8.5 when the config value is empty
 - Cast legacy scope value to string before re-encryption in `MigrateConfigPaths` data patch
+- Cast nullable values to string/int before using as array index (PHP 8.5 null array key deprecation)
 ### Changed
 - Allowed PHP range widened to `>=8.2 <8.6` in composer.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Automatic Translation
+## [2.1.2] - 21/04/2026
+### Fixed
+- PHP 8.4 and 8.5 compatibility
+- Hardened `preg_replace` return value handling in admin before-save plugins (`strtolower(null)` becomes a TypeError in PHP 8.5)
+- Cast `DOMDocument::saveHTML()` results to string before passing to `html_entity_decode()` (PHP 8.5 stricter scalar type enforcement)
+- Cast retranslation period to int before building `DateTime::modify()` string to avoid `DateMalformedStringException` in PHP 8.5 when the config value is empty
+- Cast legacy scope value to string before re-encryption in `MigrateConfigPaths` data patch
+### Changed
+- Allowed PHP range widened to `>=8.2 <8.6` in composer.json
+
 ## [2.1.0] - 20/03/2026
 ### Changed
 - Minimum PHP version lowered from 8.3 to 8.2

--- a/Helper/ModuleConfig.php
+++ b/Helper/ModuleConfig.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Store\Model\ScopeInterface;
+use Exception;
 
 class ModuleConfig extends AbstractHelper
 {
@@ -126,10 +127,11 @@ class ModuleConfig extends AbstractHelper
     /**
      * @param int $storeId
      * @return string
+     * @throws Exception
      */
     public function getTranslationExpirationDate(int $storeId = 0): string
     {
-        $retranslationDays = (string)$this->scopeConfig->getValue(
+        $retranslationDays = (int)$this->scopeConfig->getValue(
             self::RETRANSLATION_PERIOD,
             ScopeInterface::SCOPE_STORE,
             $storeId

--- a/Helper/Service.php
+++ b/Helper/Service.php
@@ -54,7 +54,7 @@ class Service extends AbstractHelper
         $result = [];
         foreach ($this->storeManager->getStores() as $store) {
             if ($this->moduleConfig->isEnable((int)$store->getId())) {
-                $result[$store->getId()] = $valueExtractor($store);
+                $result[(int)$store->getId()] = $valueExtractor($store);
             }
         }
         return $result;

--- a/Helper/Service.php
+++ b/Helper/Service.php
@@ -103,9 +103,9 @@ class Service extends AbstractHelper
                 $childDom = new DOMDocument();
                 $importedNode = $childDom->importNode($childNode, true);
                 $childDom->appendChild($importedNode);
-                $nodeHtml = html_entity_decode($childDom->saveHTML());
+                $nodeHtml = html_entity_decode((string)$childDom->saveHTML());
                 $node->replaceChild(
-                    $dom->createTextNode(str_replace(['<', '>'], ['&lt;', '&gt;'], (string)$nodeHtml)),
+                    $dom->createTextNode(str_replace(['<', '>'], ['&lt;', '&gt;'], $nodeHtml)),
                     $childNode
                 );
             }
@@ -116,7 +116,7 @@ class Service extends AbstractHelper
 
         if ($root !== null) {
             foreach ($root->childNodes as $node) {
-                $resultHtml .= $dom->saveHTML($node);
+                $resultHtml .= (string)$dom->saveHTML($node);
             }
         }
 

--- a/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlCategoryBeforeSavePlugin.php
@@ -74,7 +74,7 @@ class AdminhtmlCategoryBeforeSavePlugin
 
                     if ($attributeCode === 'url_key') {
                         $requestPostValue[$attributeCode] = strtolower(
-                            preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue[$attributeCode])
+                            (string)preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue[$attributeCode])
                         );
                     }
 

--- a/Plugin/AdminhtmlCmsBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlCmsBeforeSavePlugin.php
@@ -55,7 +55,7 @@ class AdminhtmlCmsBeforeSavePlugin
 
                     if ($attributeCode === 'identifier') {
                         $requestPostValue[$attributeCode] = strtolower(
-                            preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue[$attributeCode])
+                            (string)preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue[$attributeCode])
                         );
                     }
                 }

--- a/Plugin/AdminhtmlProductBeforeSavePlugin.php
+++ b/Plugin/AdminhtmlProductBeforeSavePlugin.php
@@ -89,7 +89,7 @@ class AdminhtmlProductBeforeSavePlugin
 
                 if ($attributeCode === 'url_key') {
                     $requestPostValue["product"][$attributeCode] = strtolower(
-                        preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue["product"][$attributeCode])
+                        (string)preg_replace('#[^0-9a-z]+#i', '-', $requestPostValue["product"][$attributeCode])
                     );
                 }
 

--- a/Service/TranslateSelectAttributes.php
+++ b/Service/TranslateSelectAttributes.php
@@ -75,7 +75,7 @@ class TranslateSelectAttributes implements TranslateSelectAttributesInterface
                         continue;
                     }
 
-                    $origLangOptionLabel = $origLangOptions[$option->getValue()];
+                    $origLangOptionLabel = $origLangOptions[(string)$option->getValue()] ?? '';
 
                     if (empty(trim($origLangOptionLabel))) {
                         continue;
@@ -172,7 +172,7 @@ class TranslateSelectAttributes implements TranslateSelectAttributesInterface
                 continue;
             }
 
-            $optionArray[$option->getValue()] = $option->getLabel();
+            $optionArray[(string)$option->getValue()] = $option->getLabel();
         }
 
         return $optionArray;

--- a/Setup/Patch/Data/MigrateConfigPaths.php
+++ b/Setup/Patch/Data/MigrateConfigPaths.php
@@ -92,7 +92,7 @@ class MigrateConfigPaths implements DataPatchInterface
         }
 
         if (in_array($oldPath, self::ENCRYPTED_OLD_PATHS, true)) {
-            $oldValue = $this->encryptor->encrypt($oldValue);
+            $oldValue = $this->encryptor->encrypt((string)$oldValue);
         }
 
         $this->configWriter->save($newPath, $oldValue, $scope, $scopeId);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.2 <8.6",
         "magento/framework": "*",
         "magento/module-catalog": "^104.0.0",
         "deeplcom/deepl-php": "^1",


### PR DESCRIPTION
Replaces #61 (closed due to branch protection preventing updates).

## Summary

This PR adds forward-compatibility for PHP 8.4 and PHP 8.5 while keeping PHP 8.2/8.3 support.

The last PHP 8.4 pass (#34) landed in 1.9.0, but a handful of spots still rely on silent null/false coercion that becomes a hard error on PHP 8.5 (where several long-standing deprecations are being promoted to TypeErrors, e.g. passing null to internal string functions, or passing a non-parseable string to `DateTime::modify()`).

cc @rhoerr @dadolun95 @SamueleMartini — happy to iterate if you want to tag this as **2.1.2** after merge.

## Fixes

- **`Plugin/Adminhtml{Category,Cms,Product}BeforeSavePlugin`**: cast the return value of `preg_replace()` to string before `strtolower()`. `preg_replace` can return `null` on failure, and `strtolower(null)` is a `TypeError` on PHP 8.5.
- **`Helper/Service::encodePageBuilderHtmlBox`**: cast `DOMDocument::saveHTML()` results to string before feeding them to `html_entity_decode()` / string concatenation. `saveHTML()` can return `false`; PHP 8.5 enforces the `string` parameter of `html_entity_decode` strictly.
- **`Helper/ModuleConfig::getTranslationExpirationDate`**: cast the retranslation-period scope value to int before building the `DateTime::modify()` expression. Previously an unset/empty config produced `- days`, which becomes a `DateMalformedStringException` on PHP 8.5.
- **`Setup/Patch/Data/MigrateConfigPaths`**: cast the legacy scope value to string before re-encrypting, since `EncryptorInterface::encrypt()` now requires a strict string on PHP 8.5.
- **Nullable values used as array index**: cast to `string`/`int` before using as array key to avoid PHP 8.5 null array key deprecation (follow-up to #61 feedback on mage-os-lab/module-widgetkit#13).
- **`composer.json`**: widen the PHP constraint to `>=8.2 <8.6` so Composer resolves cleanly on PHP 8.4 and 8.5.

No behavior change on PHP 8.2/8.3 — all casts are no-ops on valid input.

## Suggested tag

`2.1.2` (patch — backwards compatible bug fixes only).

## Test plan

- [x] `php -l` on all changed files
- [x] Manual: translate a category / product / CMS page with a populated `url_key` / `identifier` on PHP 8.5
- [x] Manual: run the translation cron on PHP 8.5 with a valid retranslation period set
