### PR TITLE
Fix PHP 8.5 ErrorException when creating a new product (null getById)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Automatic Translation
+## [2.1.3] - 13/07/2026
+### Fixed
+- Skip loading the product in the translation-stores form modifier when creating a new product (no `id` param), avoiding an `ErrorException` from passing `null` to `ProductRepository::getById()` under PHP 8.5 (null array offset deprecation)
+
 ## [2.1.2] - 21/04/2026
 ### Fixed
 - PHP 8.4 and 8.5 compatibility

--- a/Test/Unit/Ui/DataProvider/Product/Form/Modifier/TranslationStoresTest.php
+++ b/Test/Unit/Ui/DataProvider/Product/Form/Modifier/TranslationStoresTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MageOS\AutomaticTranslation\Test\Unit\Ui\DataProvider\Product\Form\Modifier;
+
+use Magento\Backend\Block\Store\Switcher as StoreSwitcher;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\App\RequestInterface;
+use MageOS\AutomaticTranslation\Helper\ModuleConfig;
+use MageOS\AutomaticTranslation\Ui\DataProvider\Product\Form\Modifier\TranslationStores;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+class TranslationStoresTest extends TestCase
+{
+    private StoreSwitcher&Stub $storeSwitcher;
+    private ModuleConfig&Stub $moduleConfig;
+    private RequestInterface&Stub $request;
+    private ProductRepositoryInterface&MockObject $productRepository;
+    private TranslationStores $modifier;
+
+    protected function setUp(): void
+    {
+        $this->storeSwitcher = $this->createStub(StoreSwitcher::class);
+        $this->moduleConfig = $this->createStub(ModuleConfig::class);
+        $this->request = $this->createStub(RequestInterface::class);
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
+
+        $this->storeSwitcher->method('getSwitchUrl')->willReturn('http://example.com/switch');
+        $this->storeSwitcher->method('getWebsites')->willReturn([]);
+
+        $this->modifier = new TranslationStores(
+            $this->storeSwitcher,
+            $this->moduleConfig,
+            $this->request,
+            $this->productRepository
+        );
+    }
+
+    /**
+     * A new product has no "id" request param; getById() must not be called with a null id
+     * (which triggers a "null as array offset" deprecation in PHP 8.5).
+     */
+    public function testNewProductDoesNotLoadProductById(): void
+    {
+        $this->request->method('getParam')->willReturn(null);
+        $this->productRepository->expects($this->never())->method('getById');
+
+        $stores = $this->getResolvedTranslationStores();
+
+        $this->assertSame([], $stores);
+    }
+
+    /**
+     * An existing product provides its id; getById() is called with the id cast to int.
+     */
+    public function testExistingProductLoadsProductById(): void
+    {
+        $this->request->method('getParam')->willReturn('5');
+
+        $product = $this->createStub(Product::class);
+        $product->method('getStoreIds')->willReturn([]);
+
+        $this->productRepository->expects($this->once())
+            ->method('getById')
+            ->with(5)
+            ->willReturn($product);
+
+        $stores = $this->getResolvedTranslationStores();
+
+        $this->assertSame([], $stores);
+    }
+
+    /**
+     * Runs the modifier and returns the resolved translationStores config it produced.
+     */
+    private function getResolvedTranslationStores(): array
+    {
+        $meta = $this->modifier->modifyMeta([]);
+
+        return $meta['select_store_modal']['children']['translation_store_list']
+            ['arguments']['data']['config']['translationStores'];
+    }
+}

--- a/Ui/DataProvider/Product/Form/Modifier/TranslationStores.php
+++ b/Ui/DataProvider/Product/Form/Modifier/TranslationStores.php
@@ -126,10 +126,15 @@ class TranslationStores extends AbstractModifier
     protected function getTranslationStores(): array
     {
         $translationStores = [];
+
+        $productId = $this->request->getParam("id");
+        if (empty($productId)) {
+            // New product form has no "id" param yet; there are no assigned stores to translate.
+            return $translationStores;
+        }
+
         try {
-            $currentProduct = $this->productRepository->getById(
-                $this->request->getParam("id")
-            );
+            $currentProduct = $this->productRepository->getById((int)$productId);
             $productStoreIds = $currentProduct->getStoreIds();
 
             foreach ($this->storeSwitcher->getWebsites() as $website) {


### PR DESCRIPTION
## Summary

Fixes mage-os/mageos-magento2#289 — creating a new product in the admin throws an `ErrorException` under PHP 8.5:

> Using null as an array offset is deprecated, use an empty string instead

### Root cause

The stack trace lands in `Magento\Catalog\Model\ProductRepository::getById()`, but the `null` originates in this module's product-form modifier:

`TranslationStores::modifyMeta` → `customizeTranslationStoresList` → `getTranslationStores()` called:

```php
$this->productRepository->getById($this->request->getParam("id"));
```

On the **Add Product** form there is no `id` request param, so `getParam("id")` returns `null`. `getById(null)` then uses `null` as an array offset internally (`$this->instancesById[null][...]`), which is a deprecation-turned-`ErrorException` in developer mode on PHP 8.5. The surrounding `try/catch` only caught `NoSuchEntityException`, so it escaped.

### Fix

Return early when there is no product id (a new product has no assigned stores to translate), and cast the id to `int` for the load. This mirrors the guard the module already uses for the CMS-block button (`!getParam('block_id')`), which is why that path was never affected.

```php
$productId = $this->request->getParam("id");
if (empty($productId)) {
    return $translationStores;
}
$currentProduct = $this->productRepository->getById((int)$productId);
```

## Tests

Adds `Test/Unit/.../TranslationStoresTest.php`:

- `getById()` is **never** called for a new product (no `id` param)
- `getById()` **is** called with the id cast to `int` for an existing product

Verified the test fails with the fix reverted and passes with it.

## Notes

- Backward compatible; no API/schema changes.
- CHANGELOG updated (`[2.1.3]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)